### PR TITLE
Drop old Linux support in favor of M1 Apple Silicon Macs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,14 +17,7 @@ gem 'sskatex'
 gem 'kramdown-math-sskatex'
 gem 'execjs'
 
-# M1 Macs must use mini_racer. therubyracer is broken: https://github.com/rubyjs/libv8/issues/312
-# Intel Macs may use either - but therubyracer requires `brew install v8@3.15` and `bundle config build.therubyracer --with-v8-dir=$(brew --prefix)/opt/v8@3.15`, while mini_racer works out of the box.
-# New Linuxes may use either.
-# Old Linuxes must use therubyracer, as mini_racer requires GCC 8+.
-# Source: https://github.com/rubyjs/libv8/issues/312#issuecomment-1200269949
-is_mac = RUBY_PLATFORM.include?('darwin')
-gem 'mini_racer', install_if: is_mac
-gem 'therubyracer', install_if: !is_mac
+gem 'mini_racer'
 gem 'libv8-node', '16.10.0.0'
 
 group :development do


### PR DESCRIPTION
Follow-up of #29 to really fix it by dropping old Linux support and fully move to `mini_racer` instead of `therubyracer`.