### PR TITLE
Add missing rackup gem

### DIFF
--- a/bin/template/Gemfile
+++ b/bin/template/Gemfile
@@ -24,6 +24,7 @@ group :development do
   gem 'guard-rack'
   gem 'guard-livereload'
   gem 'rack'
+  gem 'rackup'
   gem 'rack-livereload'
   gem 'wdm', '>= 0.1.0' if Gem.win_platform?
   gem 'rb-readline'


### PR DESCRIPTION
When newly installing ruby on linux the live reload did not work because of the missing 'rackup' gem.