### PR TITLE
Updated deprecated use of Rack.File

### DIFF
--- a/bin/template/config.ru
+++ b/bin/template/config.ru
@@ -14,4 +14,4 @@ end
 
 use IndexRewriter
 use Rack::LiveReload
-run Rack::File.new 'output'
+run Rack::Files.new 'output'


### PR DESCRIPTION
The use of `Rack.File` in the template config file is deprecated
https://github.com/rubensworks/ScholarMarkdown/blob/461bce814d0ab23b4387e81afdf6c900862a3030/bin/template/config.ru#L17
leading to the following error message:
```
<...>/config.ru:17:in `block (2 levels) in <top (required)>': uninitialized constant Rack::File (NameError)
```

[Deprecation thread in github](https://github.com/sidekiq/sidekiq/issues/4423)

Updating the line to 
```
run Rack::Files.new 'output'
```
fixes the problem